### PR TITLE
Feature/refactor repository query

### DIFF
--- a/src/repositories/solRepository.ts
+++ b/src/repositories/solRepository.ts
@@ -23,8 +23,8 @@ export class SolRepository {
       .getRawOne();
 
     for (const newSol of soles) {
-      if (!newSol.solNumberMarsDay > latestSavedSol) {
-        await solRepository.save(soles);
+      if (newSol.solNumberMarsDay > latestSavedSol) {
+        await solRepository.save(newSol);
       }
     }
   }

--- a/src/repositories/solRepository.ts
+++ b/src/repositories/solRepository.ts
@@ -22,10 +22,10 @@ export class SolRepository {
       .select('MAX(Sol.solNumberMarsDay)', 'latestSavedSol')
       .getRawOne();
 
-    for (const newSol of soles) {
-      if (newSol.solNumberMarsDay > latestSavedSol) {
-        await solRepository.save(newSol);
-      }
+    const solsToSave = soles.filter((newSol) => newSol.solNumberMarsDay > latestSavedSol);
+
+    if (solsToSave.length > 0) {
+      await solRepository.save(solsToSave);
     }
   }
 

--- a/src/repositories/solRepository.ts
+++ b/src/repositories/solRepository.ts
@@ -14,6 +14,8 @@ export class SolRepository {
    * @param soles Array of "soles" from: SolController and NasaService
    */
   public static async save14MarsDays(soles: DeepPartial<Sol[]>): Promise<void> {
+    // Encontrar o sol com solNumberMarsDay mais alto
+    // Encontrar nos soles quais tem solNumberMarsDay maior que o sol anterior
     const solRepository = MysqlDataSource.getRepository(Sol);
     const allSols: Sol[] = await solRepository.find();
 

--- a/src/repositories/solRepository.ts
+++ b/src/repositories/solRepository.ts
@@ -9,19 +9,21 @@ export class SolRepository {
   /**
    * save14MarsDays
    *
-   * Saves each newSol in the soles array is saved to the database, in case it's not already there
+   * Finds most recently saved Sol (latestSavedSol) and then saves only those in the
+   * api response with sol number (solNumberMarsDay) greater than the most recent one in the database
    *
    * @param soles Array of "soles" from: SolController and NasaService
    */
   public static async save14MarsDays(soles: DeepPartial<Sol[]>): Promise<void> {
-    // Encontrar o sol com solNumberMarsDay mais alto
-    // Encontrar nos soles quais tem solNumberMarsDay maior que o sol anterior
     const solRepository = MysqlDataSource.getRepository(Sol);
-    const allSols: Sol[] = await solRepository.find();
+
+    const { latestSavedSol } = await solRepository
+      .createQueryBuilder('Sol')
+      .select('MAX(Sol.solNumberMarsDay)', 'latestSavedSol')
+      .getRawOne();
 
     for (const newSol of soles) {
-      const repeatedSol: DeepPartial<Sol> = allSols.find((sol) => sol.solNumberMarsDay === newSol.solNumberMarsDay);
-      if (!repeatedSol) {
+      if (!newSol.solNumberMarsDay > latestSavedSol) {
         await solRepository.save(soles);
       }
     }


### PR DESCRIPTION
Nesta PR eu refatorei a query do solRepository.
Ao invés de usar 2 vezes o find, fiz assim:

1 - Encontrei qual sol salvo possui o maior solNumberMarsDay, usando createQueryBuilder e getRawOne;
2 - Salvei apenas os soles que possuem solNumberMarsDay maior que o obtido acima.