### PR TITLE
Fix: remover tratamento terrestrial date delegando o mesmo para o front

### DIFF
--- a/src/services/nasaService.ts
+++ b/src/services/nasaService.ts
@@ -57,28 +57,10 @@ export class NasaService {
    *  the soles table in the database. See solRepository.
    */
   private async selectAndSaveSolesInfo(fourteenSoles: SolMars[]): Promise<DeepPartial<Sol[]>> {
-    const months: { [key: string]: string } = {
-      '01': 'janeiro',
-      '02': 'fevereiro',
-      '03': 'março',
-      '04': 'abril',
-      '05': 'maio',
-      '06': 'junho',
-      '07': 'julho',
-      '08': 'agosto',
-      '09': 'setembro',
-      '10': 'outubro',
-      '11': 'novembro',
-      '12': 'dezembro'
-    };
     const fourteenSolesData: DeepPartial<Sol[]> = fourteenSoles.map((sol) => {
-      const dateParts: string[] = sol.terrestrial_date.split('-');
-      const day: string = dateParts[2];
-      const month: string = months[dateParts[1]];
-      const year: string = dateParts[0];
       return {
         solNumberMarsDay: parseInt(sol.sol),
-        terrestrialDate: `${day} ${month} de ${year}`,
+        terrestrialDate: sol.terrestrial_date,
         maximumTemperature: parseInt(sol.max_temp),
         minimumTemperature: parseInt(sol.min_temp)
       };


### PR DESCRIPTION
Caso se determine que o melhor para o atributo terrestrialDate de Sol, 
seja que o mesmo seja tratado no front, a correção está presente aqui. 

O motivo é que o Fabrício não conseguiu retornar o valor correto ainda.
Para não atrasar o desenvolvimento já deixo pronto esta Fix, caso seja necessário. 